### PR TITLE
Improve GPR.PY licensing compliance

### DIFF
--- a/Betatodo.py
+++ b/Betatodo.py
@@ -1,12 +1,12 @@
-# Gramps - a GTK+/GNOME based genealogy program
+# "To Do" Gramplet, a modular plugin for Gramps 
+# (Gramps - the genealogy software suite built on GTK+/GNOME) 
 #
 # Copyright (C) 2013 Nick Hall
 # Copyright (C) 2022 Brian McCullough
 # 
 # This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# it under the terms of version 2 of the GNU General Public License as 
+# published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,6 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+# For the Gramps-Project volunteer community's contact information, visit:
+# https://gramps-project.org/wiki/index.php/Contact
 
 # -------------------------------------------------------------------------
 #

--- a/Betatodogramplet.py
+++ b/Betatodogramplet.py
@@ -1,13 +1,13 @@
-# Gramps - a GTK+/GNOME based genealogy program
+# "To Do" Gramplet, a modular plugin for Gramps 
+# (Gramps - the genealogy software suite built on GTK+/GNOME) 
 #
 # Copyright (C) 2007-2009  Douglas S. Blank <doug.blank@gmail.com>
 # Copyright (C) 2013       Nick Hall
 # Copyright (C) 2022       Brian McCullough
 #
 # This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# it under the terms of version 2 of the GNU General Public License as 
+# published by the Free Software Foundation. 
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -18,6 +18,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+# For the Gramps-Project volunteer community's contact information, visit:
+# https://gramps-project.org/wiki/index.php/Contact
 
 # -------------------------------------------------------------------------
 #

--- a/Betawelcomegramplet.py
+++ b/Betawelcomegramplet.py
@@ -1,13 +1,13 @@
-# Gramps - a GTK+/GNOME based genealogy program
+# "Welcome to Gramps!" Gramplet, a modular plugin for Gramps 
+# (Gramps - the genealogy software suite built on GTK+/GNOME) 
 #
 # Copyright (C) 2007-2009  Douglas S. Blank <doug.blank@gmail.com>
 # Copyright (C) 2020       Dave Scheipers
 # Copyright (C) 2022       Brian McCullough
 #
 # This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# it under the terms of version 2 of the GNU General Public License as 
+# published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# For the Gramps-Project volunteer community's contact information, visit:
+# https://gramps-project.org/wiki/index.php/Contact
 
 # ------------------------------------------------------------------------
 #

--- a/Betawhatsnext.py
+++ b/Betawhatsnext.py
@@ -1,15 +1,15 @@
 # encoding: utf-8
 #
-# Gramps - a GTK+/GNOME based genealogy program - What Next Gramplet plugin
-#
+# "What's Next?" Gramplet, a modular plugin for Gramps 
+# (Gramps - the genealogy software suite built on GTK+/GNOME) 
+# 
 # Copyright (C) 2008 Reinhard Mueller
 # Copyright (C) 2010       Jakim Friant
 # Copyright (C) 2022       Brian McCullough
 #
 # This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# it under the terms of version 2 of the GNU General Public License as 
+# published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -20,6 +20,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+# For the Gramps-Project volunteer community's contact information, visit:
+# https://gramps-project.org/wiki/index.php/Contact
 
 # ------------------------------------------------------------------------
 #


### PR DESCRIPTION
clarify license is for a specific plugin for use with the Gramps framework

winnow out un-used options in the license
add contact info for gramps developers